### PR TITLE
Added SPEC for rpmbuild

### DIFF
--- a/skypeweb/Makefile
+++ b/skypeweb/Makefile
@@ -33,6 +33,8 @@ install:
 	mkdir -m $(DIR_PERM) -p $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/48
 	install -m $(FILE_PERM) icons/48/skype.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/48/skype.png
 	install -m $(FILE_PERM) icons/48/skypeout.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/48/skypeout.png
+	mkdir -m $(DIR_PERM) -p $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/emotes/skype
+	install -m $(FILE_PERM) theme $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/emotes/skype/theme
 clean:
 	rm -f libskypeweb.so
 

--- a/skypeweb/Makefile
+++ b/skypeweb/Makefile
@@ -1,8 +1,15 @@
 
 COMPILER = gcc
+DIR_PERM=0755
+FILE_PERM=0644
 
 LIBPURPLE_CFLAGS += $(shell pkg-config --cflags glib-2.0 json-glib-1.0 purple)
 LIBPURPLE_LIBS += $(shell pkg-config --libs glib-2.0 json-glib-1.0 purple)
+PLUGIN_DIR_PURPLE=$(shell pkg-config --variable=plugindir purple)
+DATA_ROOT_DIR_PURPLE=$(shell pkg-config --variable=datarootdir purple)
+
+PRPL_NAME=libskypeweb.so
+PRPL_LIBNAME=${PRPL_NAME}
 
 SKYPEWEB_SOURCES = \
 	skypeweb_connection.c \
@@ -13,9 +20,21 @@ SKYPEWEB_SOURCES = \
 	libskypeweb.c 
 
 .PHONY:	all clean install
-all: libskypeweb.so
+all: ${PRPL_NAME}
+install:
+	mkdir -m $(DIR_PERM) -p $(DESTDIR)$(PLUGIN_DIR_PURPLE)
+	install -m $(FILE_PERM) $(PRPL_LIBNAME) $(DESTDIR)$(PLUGIN_DIR_PURPLE)/$(PRPL_NAME)
+	mkdir -m $(DIR_PERM) -p $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/16
+	install -m $(FILE_PERM) icons/16/skype.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/16/skype.png
+	install -m $(FILE_PERM) icons/16/skypeout.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/16/skypeout.png
+	mkdir -m $(DIR_PERM) -p $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/22
+	install -m $(FILE_PERM) icons/22/skype.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/22/skype.png
+	install -m $(FILE_PERM) icons/22/skypeout.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/22/skypeout.png
+	mkdir -m $(DIR_PERM) -p $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/48
+	install -m $(FILE_PERM) icons/48/skype.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/48/skype.png
+	install -m $(FILE_PERM) icons/48/skypeout.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/48/skypeout.png
 clean:
 	rm -f libskypeweb.so
 
-libskypeweb.so: ${SKYPEWEB_SOURCES}
+${PRPL_NAME}: ${SKYPEWEB_SOURCES}
 	${COMPILER} -Wall -I. -g -O2 -fPIC -pipe ${SKYPEWEB_SOURCES} -o $@ ${LIBPURPLE_CFLAGS} ${LIBPURPLE_LIBS} -shared

--- a/skypeweb/purple-skypeweb.spec
+++ b/skypeweb/purple-skypeweb.spec
@@ -38,6 +38,7 @@ make install DESTDIR=%{buildroot}
 %{_datadir}/pixmaps/pidgin/protocols/22/skypeout.png
 %{_datadir}/pixmaps/pidgin/protocols/48/skype.png
 %{_datadir}/pixmaps/pidgin/protocols/48/skypeout.png
+%{_datadir}/pixmaps/pidgin/emotes/skype/theme
 
 %changelog
 * Mon Mar 16 2015 V1TSK <vitaly@easycoding.org> - 0.1

--- a/skypeweb/purple-skypeweb.spec
+++ b/skypeweb/purple-skypeweb.spec
@@ -9,10 +9,9 @@ License: GPLv3
 URL: https://github.com/EionRobb/skype4pidgin
 Source0: %{name}-%{version}.tar.gz
 
-BuildRequires: openssl-devel
 BuildRequires: glib2-devel
 BuildRequires: libpurple-devel
-BuildRequires: zlib-devel
+BuildRequires: json-glib-devel
 BuildRequires: gcc
 
 %description

--- a/skypeweb/purple-skypeweb.spec
+++ b/skypeweb/purple-skypeweb.spec
@@ -13,6 +13,9 @@ BuildRequires: glib2-devel
 BuildRequires: libpurple-devel
 BuildRequires: json-glib-devel
 BuildRequires: gcc
+Requires: libpurple
+Requires: pidgin
+Requires: json-glib
 
 %description
 Adds support for Skype to Pidgin, Adium, Finch and other libpurple 

--- a/skypeweb/purple-skypeweb.spec
+++ b/skypeweb/purple-skypeweb.spec
@@ -1,0 +1,42 @@
+%define debug_package %{nil}
+
+Name: purple-skypeweb
+Version: 0.1
+Release: 1
+Summary: Adds support for Skype to Pidgin
+Group: Applications/Productivity
+License: GPLv3
+URL: https://github.com/EionRobb/skype4pidgin
+Source0: %{name}-%{version}.tar.gz
+
+BuildRequires: openssl-devel
+BuildRequires: glib2-devel
+BuildRequires: libpurple-devel
+BuildRequires: zlib-devel
+BuildRequires: gcc
+
+%description
+Adds support for Skype to Pidgin, Adium, Finch and other libpurple 
+based messengers.
+
+%prep
+%setup -c
+
+%build
+make
+
+%install
+make install DESTDIR=%{buildroot}
+
+%files
+%{_libdir}/purple-2/libskypeweb.so
+%{_datadir}/pixmaps/pidgin/protocols/16/skype.png
+%{_datadir}/pixmaps/pidgin/protocols/16/skypeout.png
+%{_datadir}/pixmaps/pidgin/protocols/22/skype.png
+%{_datadir}/pixmaps/pidgin/protocols/22/skypeout.png
+%{_datadir}/pixmaps/pidgin/protocols/48/skype.png
+%{_datadir}/pixmaps/pidgin/protocols/48/skypeout.png
+
+%changelog
+* Mon Mar 16 2015 V1TSK <vitaly@easycoding.org> - 0.1
+- Created first RPM spec for Fedora/openSUSE.


### PR DESCRIPTION
Added -install section in default makefile (needed by RPM-build).

Added SPEC for rpmbuild. RPM packages for Fedora 20+, CentOS, RHEL and openSUSE can be built by `rpmbuild -ba purple-skypeweb.spec`.