### PR TITLE
RPM spec file updates

### DIFF
--- a/skypeweb/README.md
+++ b/skypeweb/README.md
@@ -28,7 +28,7 @@ Requires devel headers/libs for libpurple and json-glib, gcc compiler and rpmbui
 ```
 	sudo yum install git rpm-build gcc json-glib-devel libpurple-devel pidgin-devel
 	cd skype4pidgin/skypeweb
-	tar -czf purple-skypeweb-0.1.tar.gz *
-	rpmbuild -tb purple-skypeweb-0.1.tar.gz
+	tar -czf skypeweb.tar.gz *
+	rpmbuild -tb skypeweb.tar.gz
 ```
 The result can be found in ``~/rpmbuild/RPMS/`uname -m`/`` directory.

--- a/skypeweb/purple-skypeweb.spec
+++ b/skypeweb/purple-skypeweb.spec
@@ -2,7 +2,7 @@
 
 Name: purple-skypeweb
 Version: 0.1
-Release: 1
+Release: 2
 Summary: Adds support for Skype to Pidgin
 Group: Applications/Productivity
 License: GPLv3
@@ -14,12 +14,19 @@ BuildRequires: libpurple-devel
 BuildRequires: json-glib-devel
 BuildRequires: gcc
 Requires: libpurple
-Requires: pidgin
 Requires: json-glib
+
+%package -n pidgin-skypeweb
+Summary: Adds pixmaps, icons and smileys for Skype protocol inplemented by libskypeweb.
+Requires: purple-skypeweb
+Requires: pidgin
 
 %description
 Adds support for Skype to Pidgin, Adium, Finch and other libpurple 
 based messengers.
+
+%description -n pidgin-skypeweb
+Adds pixmaps, icons and smileys for Skype protocol.
 
 %prep
 %setup -c
@@ -32,6 +39,8 @@ make install DESTDIR=%{buildroot}
 
 %files
 %{_libdir}/purple-2/libskypeweb.so
+
+%files -n pidgin-skypeweb
 %{_datadir}/pixmaps/pidgin/protocols/16/skype.png
 %{_datadir}/pixmaps/pidgin/protocols/16/skypeout.png
 %{_datadir}/pixmaps/pidgin/protocols/22/skype.png
@@ -41,5 +50,8 @@ make install DESTDIR=%{buildroot}
 %{_datadir}/pixmaps/pidgin/emotes/skype/theme
 
 %changelog
-* Mon Mar 16 2015 V1TSK <vitaly@easycoding.org> - 0.1
+* Sat May 09 2015 V1TSK <vitaly@easycoding.org> - 0.1-2
+- Separated packages. Now can be used with other libpurple-based clients without Pidgin being installed.
+
+* Mon Mar 16 2015 V1TSK <vitaly@easycoding.org> - 0.1-1
 - Created first RPM spec for Fedora/openSUSE.

--- a/skypeweb/purple-skypeweb.spec
+++ b/skypeweb/purple-skypeweb.spec
@@ -7,7 +7,7 @@ Summary: Adds support for Skype to Pidgin
 Group: Applications/Productivity
 License: GPLv3
 URL: https://github.com/EionRobb/skype4pidgin
-Source0: %{name}-%{version}.tar.gz
+Source0: %{name}.tar.gz
 
 BuildRequires: glib2-devel
 BuildRequires: libpurple-devel

--- a/skypeweb/purple-skypeweb.spec
+++ b/skypeweb/purple-skypeweb.spec
@@ -1,8 +1,9 @@
 %define debug_package %{nil}
+%define plugin_name skypeweb
 
-Name: purple-skypeweb
+Name: purple-%{plugin_name}
 Version: 0.1
-Release: 2
+Release: 1
 Summary: Adds support for Skype to Pidgin
 Group: Applications/Productivity
 License: GPLv3
@@ -16,16 +17,16 @@ BuildRequires: gcc
 Requires: libpurple
 Requires: json-glib
 
-%package -n pidgin-skypeweb
+%package -n pidgin-%{plugin_name}
 Summary: Adds pixmaps, icons and smileys for Skype protocol.
-Requires: purple-skypeweb
+Requires: %{name}
 Requires: pidgin
 
 %description
 Adds support for Skype to Pidgin, Adium, Finch and other libpurple 
 based messengers.
 
-%description -n pidgin-skypeweb
+%description -n pidgin-%{plugin_name}
 Adds pixmaps, icons and smileys for Skype protocol inplemented by libskypeweb.
 
 %prep
@@ -40,7 +41,7 @@ make install DESTDIR=%{buildroot}
 %files
 %{_libdir}/purple-2/libskypeweb.so
 
-%files -n pidgin-skypeweb
+%files -n pidgin-%{plugin_name}
 %{_datadir}/pixmaps/pidgin/protocols/16/skype.png
 %{_datadir}/pixmaps/pidgin/protocols/16/skypeout.png
 %{_datadir}/pixmaps/pidgin/protocols/22/skype.png

--- a/skypeweb/purple-skypeweb.spec
+++ b/skypeweb/purple-skypeweb.spec
@@ -8,7 +8,7 @@ Summary: Adds support for Skype to Pidgin
 Group: Applications/Productivity
 License: GPLv3
 URL: https://github.com/EionRobb/skype4pidgin
-Source0: %{name}.tar.gz
+Source0: %{plugin_name}.tar.gz
 
 BuildRequires: glib2-devel
 BuildRequires: libpurple-devel

--- a/skypeweb/purple-skypeweb.spec
+++ b/skypeweb/purple-skypeweb.spec
@@ -17,7 +17,7 @@ Requires: libpurple
 Requires: json-glib
 
 %package -n pidgin-skypeweb
-Summary: Adds pixmaps, icons and smileys for Skype protocol inplemented by libskypeweb.
+Summary: Adds pixmaps, icons and smileys for Skype protocol.
 Requires: purple-skypeweb
 Requires: pidgin
 
@@ -26,7 +26,7 @@ Adds support for Skype to Pidgin, Adium, Finch and other libpurple
 based messengers.
 
 %description -n pidgin-skypeweb
-Adds pixmaps, icons and smileys for Skype protocol.
+Adds pixmaps, icons and smileys for Skype protocol inplemented by libskypeweb.
 
 %prep
 %setup -c


### PR DESCRIPTION
Separated packages. Now can be used with other libpurple-based clients without Pidgin being installed.

Rpmbuild will now build two packages: purple-skypeweb and pidgin-skypeweb. First contains only plugin. Graphics and smiley themes can be found in second.