### PR TITLE
MSYS2 build and Pidgin variant support for SkypeWeb

### DIFF
--- a/skypeweb/Makefile.eion
+++ b/skypeweb/Makefile.eion
@@ -41,7 +41,13 @@ install:
 
 installers:	libskypeweb.dll pidgin-skypeweb.nsi
 	date=`date +%d-%b-%Y` && sed "s/PRODUCT_VERSION \"[-a-z0-9A-Z]*\"/PRODUCT_VERSION \"$$date\"/" -i pidgin-skypeweb.nsi
-	$(MAKENSIS) pidgin-skypeweb.nsi > /dev/null
+	$(MAKENSIS) \
+		-DPIDGIN_VARIANT="Pidgin" \
+		-DPRODUCT_NAME="pidgin-skypeweb" \
+		-DINSTALLER_NAME="pidgin-skypeweb-installer" \
+		-DPRODUCT_VERSION="$(shell date +%d-%b-%Y)" \
+		-JSON_GLIB_DLL="libjson-glib-1.0.dll" \
+		pidgin-skypeweb.nsi > /dev/null
 
 clean:
 	rm -f libskypeweb.dll

--- a/skypeweb/Makefile.msys2
+++ b/skypeweb/Makefile.msys2
@@ -1,0 +1,60 @@
+# MSYS2 makefile for SkypeWeb
+
+ifndef PIDGIN_BUILD_DIR
+    $(error PIDGIN_BUILD_DIR is required)
+endif
+
+COMPILER ?= gcc.exe
+OBJCOPY ?= objcopy.exe
+MAKENSIS ?= makensis.exe
+PIDGIN_VARIANT ?= Pidgin
+PRODUCT_NAME ?= $(PIDGIN_VARIANT) SkypeWeb
+INSTALLER_NAME ?= $(PRODUCT_NAME) Setup
+
+REVISION_ID = $(shell git rev-parse --short HEAD)
+REVISION_NUMBER = $(shell git rev-list --count HEAD)
+ifneq ($(REVISION_ID),)
+PRODUCT_VERSION ?= R$(REVISION_NUMBER).$(REVISION_ID)
+else
+PRODUCT_VERSION ?= $(shell date +%d-%b-%Y)
+endif
+
+MINGW_PREFIX = $(shell which gcc | awk -F/bin/ '{ printf $$1 }')
+LIBPURPLE_CFLAGS = -DPURPLE_PLUGINS -DENABLE_NLS -DHAVE_ZLIB
+CFLAGS = -Wno-format -I${PIDGIN_BUILD_DIR}/libpurple -I${PIDGIN_BUILD_DIR}/libpurple/win32 $(shell pkg-config --cflags json-glib-1.0)
+LIBS = -L${PIDGIN_BUILD_DIR}/libpurple -lglib-2.0 -lgobject-2.0 -lintl -lpurple -lws2_32 -ljson-glib-1.0 -lz -lnss3
+JSON_GLIB_DLL = libjson-glib-1.0-0.dll
+
+SKYPEWEB_SOURCES = \
+	skypeweb_connection.c \
+	skypeweb_contacts.c \
+	skypeweb_login.c \
+	skypeweb_messages.c \
+	skypeweb_util.c \
+	libskypeweb.c
+
+.PHONY: all clean
+
+all: libskypeweb.dll
+
+libskypeweb.dll: ${SKYPEWEB_SOURCES}
+	${COMPILER} ${LIBPURPLE_CFLAGS} -Wall -I. -g -O2 -pipe ${SKYPEWEB_SOURCES} -o $@ -shared ${CFLAGS} ${LIBS}
+	${OBJCOPY} --only-keep-debug $@ $@.dbg
+	${OBJCOPY} --strip-debug $@
+	${OBJCOPY} --add-gnu-debuglink=$@.dbg $@
+
+libskypeweb-debug.dll: ${SKYPEWEB_SOURCES}
+	${COMPILER} ${LIBPURPLE_CFLAGS} -Wall -I. -g -O0 -pipe ${SKYPEWEB_SOURCES} -o $@ -shared ${CFLAGS} ${LIBS}
+
+installer: libskypeweb.dll
+	cp $(MINGW_PREFIX)/bin/$(JSON_GLIB_DLL) .
+	$(MAKENSIS) \
+		-DPRODUCT_NAME="$(PRODUCT_NAME)" \
+		-DINSTALLER_NAME="$(INSTALLER_NAME)" \
+		-DPRODUCT_VERSION="$(PRODUCT_VERSION)" \
+		-DPIDGIN_VARIANT="$(PIDGIN_VARIANT)" \
+		-DJSON_GLIB_DLL="$(JSON_GLIB_DLL)" \
+		pidgin-skypeweb.nsi
+
+clean:
+	rm -f $(JSON_GLIB_DLL) libskypeweb.dll libskypeweb-debug.dll *.dll.dbg *.exe

--- a/skypeweb/pidgin-skypeweb.nsi
+++ b/skypeweb/pidgin-skypeweb.nsi
@@ -5,8 +5,6 @@ SetCompress off
 
 ; todo: SetBrandingImage
 ; HM NIS Edit Wizard helper defines
-!define PRODUCT_NAME "pidgin-skypeweb"
-!define PRODUCT_VERSION ""
 !define PRODUCT_PUBLISHER "Eion Robb"
 !define PRODUCT_WEB_SITE "http://eion.robbmob.com/"
 !define PRODUCT_UNINST_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}"
@@ -33,7 +31,7 @@ SetCompress off
 !define MUI_FINISHPAGE_SHOWREADME "http://eion.robbmob.com/README.txt"
 !define MUI_FINISHPAGE_SHOWREADME_NOTCHECKED
 !define MUI_FINISHPAGE_RUN
-!define MUI_FINISHPAGE_RUN_TEXT "Run Pidgin"
+!define MUI_FINISHPAGE_RUN_TEXT "Run ${PIDGIN_VARIANT}"
 !define MUI_FINISHPAGE_RUN_FUNCTION "RunPidgin"
 !insertmacro MUI_PAGE_FINISH
 
@@ -46,8 +44,8 @@ SetCompress off
 ; MUI end ------
 
 Name "${PRODUCT_NAME} ${PRODUCT_VERSION}"
-OutFile "${PRODUCT_NAME}-installer.exe"
-InstallDir "$PROGRAMFILES\Pidgin"
+OutFile "${INSTALLER_NAME}.exe"
+InstallDir "$PROGRAMFILES\${PIDGIN_VARIANT}"
 
 Var "PidginDir"
 
@@ -62,7 +60,7 @@ Section "MainSection" SEC01
     SetOverwrite try
 	
 	SetOutPath "$PidginDir"
-	File "libjson-glib-1.0.dll"
+	File "${JSON_GLIB_DLL}"
     
 	SetOutPath "$PidginDir\pixmaps\pidgin"
 	File "/oname=protocols\16\skype.png" "icons\16\skype.png"
@@ -84,7 +82,7 @@ Section "MainSection" SEC01
 	dllbusy:
 		Delete "$PidginDir\plugins\libskypeweb.dllold"
 		Rename  "$PidginDir\plugins\libskypeweb.dll" "$PidginDir\plugins\libskypeweb.dllold"
-		MessageBox MB_OK "Old version of plugin detected.  You will need to restart Pidgin to complete installation"
+		MessageBox MB_OK "Old version of plugin detected.  You will need to restart ${PIDGIN_VARIANT} to complete installation"
 		Goto copy
 	after_copy:
 		Call RegisterURIHandler
@@ -103,12 +101,12 @@ FunctionEnd
 
 Function GetPidginInstPath
   Push $0
-  ReadRegStr $0 HKLM "Software\pidgin" ""
+  ReadRegStr $0 HKLM "Software\${PIDGIN_VARIANT}" ""
 	IfFileExists "$0\pidgin.exe" cont
-	ReadRegStr $0 HKCU "Software\pidgin" ""
+	ReadRegStr $0 HKCU "Software\${PIDGIN_VARIANT}" ""
 	IfFileExists "$0\pidgin.exe" cont
-		MessageBox MB_OK|MB_ICONINFORMATION "Failed to find Pidgin installation."
-		Abort "Failed to find Pidgin installation. Please install Pidgin first."
+		MessageBox MB_OK|MB_ICONINFORMATION "Failed to find ${PIDGIN_VARIANT} installation."
+		Abort "Failed to find ${PIDGIN_VARIANT} installation. Please install ${PIDGIN_VARIANT} first."
   cont:
 	StrCpy $PidginDir $0
 FunctionEnd


### PR DESCRIPTION
The installer is now customizable as to which Pidgin variant it will be targeted against. SkypeWeb now builds under MSYS2 too. The `Makefile.eion` should continue working the same way. Example for producing installers for both Pidgin and Pidgin++:

```
$ make -f Makefile.msys2 PIDGIN_BUILD_DIR="/somewhere"
$ make -f Makefile.msys2 PIDGIN_BUILD_DIR="/somewhere" PIDGIN_VARIANT="Pidgin++"
```