### PR TITLE
Connection status fix

### DIFF
--- a/skypeweb/.gitignore
+++ b/skypeweb/.gitignore
@@ -1,0 +1,1 @@
+libskypeweb.so

--- a/skypeweb/libskypeweb.c
+++ b/skypeweb/libskypeweb.c
@@ -33,12 +33,13 @@ skypeweb_do_all_the_things(SkypeWebAccount *sa)
 			purple_timeout_remove(sa->authcheck_timeout);
 		skypeweb_check_authrequests(sa);
 		sa->authcheck_timeout = purple_timeout_add_seconds(120, (GSourceFunc)skypeweb_check_authrequests, sa);
-		
+		purple_connection_set_state(sa->pc, PURPLE_CONNECTED);
+
 		skypeweb_get_friend_list(sa);
 		skypeweb_poll(sa);
 		
 		skype_web_get_offline_history(sa);
-		
+
 		skypeweb_set_status(sa->account, purple_account_get_active_status(sa->account));
 	} else {
 		//Too soon!

--- a/skypeweb/skypeweb_login.c
+++ b/skypeweb/skypeweb_login.c
@@ -51,8 +51,6 @@ skypeweb_login_did_auth(PurpleUtilFetchUrlData *url_data, gpointer user_data, co
 	
 	skypeweb_update_cookies(sa, url_text);
 	
-	purple_connection_set_state(sa->pc, PURPLE_CONNECTED);
-	
 	skypeweb_do_all_the_things(sa);
 }
 


### PR DESCRIPTION
Don't become connected without valid registration token

The signed-on event fired before we connected to Skype in cases where the registration token wasn't valid. This led to clients thinking they could operated as if the user was logged in (send messages etc.) when they could not. The status change now lives in do_all_the_things(), where it only takes place if there is a valid registration.