### PR TITLE
Fix an issue where a chat was joined but messages couldn't be sent

### DIFF
--- a/skypeweb/skypeweb_messages.c
+++ b/skypeweb/skypeweb_messages.c
@@ -1074,8 +1074,12 @@ skypeweb_chat_send(PurpleConnection *pc, gint id, const gchar *message, PurpleMe
 	
 	chatconv = purple_conversations_find_chat(pc, id);
 	chatname = purple_conversation_get_data(PURPLE_CONVERSATION(chatconv), "chatname");
-	if (!chatname)
-		return -1;
+	if (!chatname) {
+		// Fix for a condition around the chat data and serv_got_joined_chat()
+		chatname = purple_conversation_get_name(PURPLE_CONVERSATION(chatconv));
+		if (!chatname)
+			return -1;
+        }
 
 	skypeweb_send_message(sa, chatname, message);
 

--- a/skypeweb/skypeweb_messages.c
+++ b/skypeweb/skypeweb_messages.c
@@ -1070,7 +1070,7 @@ skypeweb_chat_send(PurpleConnection *pc, gint id, const gchar *message, PurpleMe
 	SkypeWebAccount *sa = purple_connection_get_protocol_data(pc);
 	
 	PurpleChatConversation *chatconv;
-	gchar* chatname;
+	const gchar* chatname;
 	
 	chatconv = purple_conversations_find_chat(pc, id);
 	chatname = purple_conversation_get_data(PURPLE_CONVERSATION(chatconv), "chatname");


### PR DESCRIPTION
The message sending code expected a "chatname" attribute to be set on chats to which message were sent. When the chat-joined event fired, this attribute was not set. This caused sending messages from a chat-joined callback to fail.

This commit fixes this issue by attempting to fall back to the name field on the conversation if the "chatname" attribute is not set.