### PR TITLE
fix for auto-build packages

### DIFF
--- a/skypeweb/README.md
+++ b/skypeweb/README.md
@@ -26,10 +26,13 @@ Building RPM package for Fedora/openSUSE/CentOS/RHEL
 ---------
 Requires devel headers/libs for libpurple and json-glib, gcc compiler and rpmbuild tool
 ```
-	sudo yum install git rpm-build gcc json-glib-devel libpurple-devel pidgin-devel
-	cd skype4pidgin/skypeweb
-	tar -czf skypeweb.tar.gz *
-	rpmbuild -tb skypeweb.tar.gz
+	sudo yum install git rpm-build gcc json-glib-devel libpurple-devel zlib-devel make automake glib2-devel -y
+	mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+	wget https://raw.githubusercontent.com/EionRobb/skype4pidgin/master/skypeweb/purple-skypeweb.spec \
+		-O ~/rpmbuild/SPECS/purple-skypeweb.spec
+	wget https://github.com/EionRobb/skype4pidgin/archive/master.tar.gz \
+		-O ~/rpmbuild/SOURCES/skype4pidgin-0.1.tar.gz
+	rpmbuild -ba  ~/rpmbuild/SPECS/purple-skypeweb.spec
 ```
 The result can be found in ``~/rpmbuild/RPMS/`uname -m`/`` directory.
 

--- a/skypeweb/README.md
+++ b/skypeweb/README.md
@@ -26,7 +26,7 @@ Building RPM package for Fedora/openSUSE/CentOS/RHEL
 ---------
 Requires devel headers/libs for libpurple and json-glib, gcc compiler and rpmbuild tool
 ```
-	sudo yum install git rpm-build gcc json-glib-devel libpurple-devel zlib-devel make automake glib2-devel -y
+	sudo yum install rpm-build gcc json-glib-devel libpurple-devel zlib-devel make automake glib2-devel -y
 	mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 	wget https://raw.githubusercontent.com/EionRobb/skype4pidgin/master/skypeweb/purple-skypeweb.spec \
 		-O ~/rpmbuild/SPECS/purple-skypeweb.spec

--- a/skypeweb/purple-skypeweb.spec
+++ b/skypeweb/purple-skypeweb.spec
@@ -40,15 +40,15 @@ Adds pixmaps, icons and smileys for Skype protocol inplemented by libskypeweb.
 %setup -c
 
 %build -n %{purplelib_name}
-cd %{project_name}-*/skypeweb
+cd %{project_name}-*/%{plugin_name}
 make
 
 %install
-cd %{project_name}-*/skypeweb
+cd %{project_name}-*/%{plugin_name}
 make install DESTDIR=%{buildroot}
 
 %files -n %{purplelib_name}
-%{_libdir}/purple-2/libskypeweb.so
+%{_libdir}/purple-2/lib%{plugin_name}.so
 
 %files -n pidgin-%{plugin_name}
 %{_datadir}/pixmaps/pidgin/protocols/16/skype.png

--- a/skypeweb/purple-skypeweb.spec
+++ b/skypeweb/purple-skypeweb.spec
@@ -1,15 +1,22 @@
 %define debug_package %{nil}
 %define plugin_name skypeweb
+%define project_name skype4pidgin
+%define purplelib_name purple-%{plugin_name}
 
-Name: purple-%{plugin_name}
+Name: %{project_name}
 Version: 0.1
 Release: 1
-Summary: Adds support for Skype to Pidgin
+Summary: Skype plugin for Pidgin/Adium/libpurple
 Group: Applications/Productivity
 License: GPLv3
 URL: https://github.com/EionRobb/skype4pidgin
-Source0: %{plugin_name}.tar.gz
+Source0: %{project_name}-%{version}.tar.gz
 
+%description
+meta pkj.
+
+%package -n %{purplelib_name}
+Summary: Adds support for Skype to Pidgin
 BuildRequires: glib2-devel
 BuildRequires: libpurple-devel
 BuildRequires: json-glib-devel
@@ -22,23 +29,25 @@ Summary: Adds pixmaps, icons and smileys for Skype protocol.
 Requires: %{name}
 Requires: pidgin
 
-%description
+%description -n %{purplelib_name}
 Adds support for Skype to Pidgin, Adium, Finch and other libpurple 
 based messengers.
 
 %description -n pidgin-%{plugin_name}
 Adds pixmaps, icons and smileys for Skype protocol inplemented by libskypeweb.
 
-%prep
+%prep -n %{purplelib_name}
 %setup -c
 
-%build
+%build -n %{purplelib_name}
+cd %{project_name}-*/skypeweb
 make
 
 %install
+cd %{project_name}-*/skypeweb
 make install DESTDIR=%{buildroot}
 
-%files
+%files -n %{purplelib_name}
 %{_libdir}/purple-2/libskypeweb.so
 
 %files -n pidgin-%{plugin_name}


### PR DESCRIPTION
fixes spec for [work with OBS] (https://build.opensuse.org/package/show/home:BOPOHA/purple-skypeweb) + creating RPMs from main tarball master.tar.gz .
It's needed for creating [ready to use] (https://software.opensuse.org/download.html?project=home%3ABOPOHA&package=purple-skypeweb) package repositories.