### PR TITLE
Some notification settings to handle "Control/Typing" events

### DIFF
--- a/skypeweb/libskypeweb.c
+++ b/skypeweb/libskypeweb.c
@@ -688,7 +688,7 @@ skypeweb_protocol_init(PurpleProtocol *prpl_info)
 {
 	PurpleProtocol *info = prpl_info;
 #endif
-	PurpleAccountOption *option;
+	PurpleAccountOption *option,  *typing_type1, *typing_type2;
 	PurpleBuddyIconSpec icon_spec = {"jpeg", 0, 0, 96, 96, 0, PURPLE_ICON_SCALE_DISPLAY};
 
 	//PurpleProtocol
@@ -696,11 +696,18 @@ skypeweb_protocol_init(PurpleProtocol *prpl_info)
 	info->name = "Skype (HTTP)";
 	prpl_info->options = OPT_PROTO_CHAT_TOPIC | OPT_PROTO_INVITE_MESSAGE /*| OPT_PROTO_IM_IMAGE*/;
 	option = purple_account_option_bool_new("", "", FALSE);
+	typing_type1 = purple_account_option_bool_new(N_("Show 'Typing' status as system message in chat window."), "show-typing-as-text", FALSE);
+	typing_type2 = purple_account_option_bool_new(N_("Show 'Typing' status with 'Voice' icon near buddy name."), "show-typing-as-icon", FALSE);
+
 #if !PURPLE_VERSION_CHECK(3, 0, 0)
 	prpl_info->protocol_options = g_list_append(prpl_info->protocol_options, option);
+	prpl_info->protocol_options = g_list_append(prpl_info->protocol_options, typing_type1);
+	prpl_info->protocol_options = g_list_append(prpl_info->protocol_options, typing_type2);
 	prpl_info->icon_spec = icon_spec;
 #else
 	prpl_info->account_options = g_list_append(prpl_info->account_options, option);
+	prpl_info->account_options = g_list_append(prpl_info->account_options, typing_type1);
+	prpl_info->account_options = g_list_append(prpl_info->account_options, typing_type2);
 	prpl_info->icon_spec = &icon_spec;
 #endif
 	

--- a/skypeweb/libskypeweb.h
+++ b/skypeweb/libskypeweb.h
@@ -123,6 +123,10 @@
 	#define PurpleChatUserFlags PurpleConvChatBuddyFlags
 	#define PURPLE_CHAT_USER_NONE PURPLE_CBFLAGS_NONE
 	#define PURPLE_CHAT_USER_OP PURPLE_CBFLAGS_OP
+	#define PURPLE_CHAT_USER_FOUNDER PURPLE_CBFLAGS_FOUNDER
+	#define PURPLE_CHAT_USER_TYPING PURPLE_CBFLAGS_TYPING
+	#define PURPLE_CHAT_USER_AWAY PURPLE_CBFLAGS_AWAY
+	#define PURPLE_CHAT_USER_HALFOP PURPLE_CBFLAGS_HALFOP
 	#define PURPLE_CHAT_USER_VOICE PURPLE_CBFLAGS_VOICE
 	#define purple_serv_got_joined_chat(pc, id, name) PURPLE_CONV_CHAT(serv_got_joined_chat(pc, id, name))
 	#define purple_serv_got_chat_invite serv_got_chat_invite


### PR DESCRIPTION
Here is some changes to resolve issue https://github.com/EionRobb/skype4pidgin/issues/328
Some notes:
* two new options added to account settings, first enables "buddy typing ..." message when someone typing, second - will change buddy status icon to 'Voice' when he typing
* not sure is empty option needed
* only two roles allowed in new unmoderated chats: *admin* and *user*,  so I changed their default flags to OP and HALFOP and played a bit with other flags to return their original status flags when message finally typed and sent