### PR TITLE
[SkypeWeb] Add missing files to spec file list

### DIFF
--- a/skypeweb/purple-skypeweb.spec
+++ b/skypeweb/purple-skypeweb.spec
@@ -52,18 +52,19 @@ make install DESTDIR=%{buildroot}
 %{_libdir}/purple-2/lib%{plugin_name}.so
 
 %files -n pidgin-%{plugin_name}
-%{_datadir}/pixmaps/pidgin
-%{_datadir}/pixmaps/pidgin/protocols
-%{_datadir}/pixmaps/pidgin/protocols/16
+%dir %{_datadir}/pixmaps/pidgin
+%dir %{_datadir}/pixmaps/pidgin/protocols
+%dir %{_datadir}/pixmaps/pidgin/protocols/16
 %{_datadir}/pixmaps/pidgin/protocols/16/skype.png
 %{_datadir}/pixmaps/pidgin/protocols/16/skypeout.png
-%{_datadir}/pixmaps/pidgin/protocols/22
+%dir %{_datadir}/pixmaps/pidgin/protocols/22
 %{_datadir}/pixmaps/pidgin/protocols/22/skype.png
 %{_datadir}/pixmaps/pidgin/protocols/22/skypeout.png
-%{_datadir}/pixmaps/pidgin/protocols/48
+%dir %{_datadir}/pixmaps/pidgin/protocols/48
 %{_datadir}/pixmaps/pidgin/protocols/48/skype.png
 %{_datadir}/pixmaps/pidgin/protocols/48/skypeout.png
-%{_datadir}/pixmaps/pidgin/emotes
+%dir %{_datadir}/pixmaps/pidgin/emotes
+%dir %{_datadir}/pixmaps/pidgin/emotes/skype
 %{_datadir}/pixmaps/pidgin/emotes/skype/theme
 
 %files

--- a/skypeweb/purple-skypeweb.spec
+++ b/skypeweb/purple-skypeweb.spec
@@ -52,12 +52,18 @@ make install DESTDIR=%{buildroot}
 %{_libdir}/purple-2/lib%{plugin_name}.so
 
 %files -n pidgin-%{plugin_name}
+%{_datadir}/pixmaps/pidgin
+%{_datadir}/pixmaps/pidgin/protocols
+%{_datadir}/pixmaps/pidgin/protocols/16
 %{_datadir}/pixmaps/pidgin/protocols/16/skype.png
 %{_datadir}/pixmaps/pidgin/protocols/16/skypeout.png
+%{_datadir}/pixmaps/pidgin/protocols/22
 %{_datadir}/pixmaps/pidgin/protocols/22/skype.png
 %{_datadir}/pixmaps/pidgin/protocols/22/skypeout.png
+%{_datadir}/pixmaps/pidgin/protocols/48
 %{_datadir}/pixmaps/pidgin/protocols/48/skype.png
 %{_datadir}/pixmaps/pidgin/protocols/48/skypeout.png
+%{_datadir}/pixmaps/pidgin/emotes
 %{_datadir}/pixmaps/pidgin/emotes/skype/theme
 
 %files


### PR DESCRIPTION
When packaging for OpenSUSE, it is required that all folders which are not part of the general filesystem to be owned by the package too. If the folders are missing, the package building fails on openSUSE's Open Build System.

This adds the missing folders to the list in the spec file so it can be used in obs without any changes for both Fedora and OpenSUSE.