### PR TITLE
Keep track of PurpleUtilFetchUrlData and cancel them on logout

### DIFF
--- a/skypeweb/libskypeweb.c
+++ b/skypeweb/libskypeweb.c
@@ -367,6 +367,11 @@ skypeweb_close(PurpleConnection *pc)
 		sa->dns_queries = g_slist_remove(sa->dns_queries, dns_query);
 		purple_dnsquery_destroy(dns_query);
 	}
+
+	while (sa->url_datas) {
+		purple_util_fetch_url_cancel(sa->url_datas->data);
+		sa->url_datas = g_slist_delete_link(sa->url_datas, sa->url_datas);
+	}
 	
 	g_hash_table_destroy(sa->sent_messages_hash);
 	g_hash_table_destroy(sa->cookie_table);

--- a/skypeweb/libskypeweb.h
+++ b/skypeweb/libskypeweb.h
@@ -272,6 +272,8 @@ struct _SkypeWebAccount {
 	gchar *registration_token;
 	gchar *endpoint;
 	gint registration_expiry;
+
+	GSList *url_datas; /**< PurpleUtilFetchUrlData to be cancelled on logout */
 };
 
 struct _SkypeWebBuddy {

--- a/skypeweb/skypeweb_messages.c
+++ b/skypeweb/skypeweb_messages.c
@@ -992,6 +992,8 @@ skypeweb_got_registration_token(PurpleUtilFetchUrlData *url_data, gpointer user_
 	gchar *expires;
 	SkypeWebAccount *sa = user_data;
 	gchar *new_messages_host;
+
+	sa->url_datas = g_slist_remove(sa->url_datas, url_data);
 	
 	if (url_text == NULL) {
 		url_text = url_data->webdata;
@@ -1075,8 +1077,10 @@ skypeweb_get_registration_token(SkypeWebAccount *sa)
 	
 	//purple_debug_info("skypeweb", "reg token request is %s\n", request);
 	
-	requestdata = purple_util_fetch_url_request(sa->account, messages_url, TRUE, NULL, FALSE, request, TRUE, 524288, skypeweb_got_registration_token, sa);
-	requestdata->num_times_redirected = 10; /* Prevent following redirects */
+	requestdata = skypeweb_fetch_url_request(sa, messages_url, TRUE, NULL, FALSE, request, TRUE, 524288, skypeweb_got_registration_token, sa);
+
+	if (requestdata != NULL)
+		requestdata->num_times_redirected = 10; /* Prevent following redirects */
 
 	g_free(request);
 	g_free(curtime);

--- a/skypeweb/skypeweb_util.c
+++ b/skypeweb/skypeweb_util.c
@@ -247,3 +247,24 @@ find_acct(const char *prpl, const char *acct_id)
 	
 	return acct;
 }
+
+
+/* Wrapper of purple_util_fetch_url_request_len_with_account()
+ * that takes a SkypeWebAccount instead of a PurpleAccount,
+ * and keeps track of requests in sa->url_datas to cancel them on logout. */
+
+PurpleUtilFetchUrlData *
+skypeweb_fetch_url_request(SkypeWebAccount *sa,
+		const char *url, gboolean full, const char *user_agent, gboolean http11,
+		const char *request, gboolean include_headers, gssize max_len,
+		PurpleUtilFetchUrlCallback callback, void *user_data)
+{
+	PurpleUtilFetchUrlData *url_data;
+
+	url_data = purple_util_fetch_url_request(sa->account, url, full, user_agent, http11, request, include_headers, max_len, callback, user_data);
+
+	if (url_data != NULL)
+		sa->url_datas = g_slist_prepend(sa->url_datas, url_data);
+
+	return url_data;
+}

--- a/skypeweb/skypeweb_util.h
+++ b/skypeweb/skypeweb_util.h
@@ -30,3 +30,9 @@ gchar *skypeweb_hmac_sha256(gchar *input);
 gint64 skypeweb_get_js_time();
 
 PurpleAccount *find_acct(const char *prpl, const char *acct_id);
+
+PurpleUtilFetchUrlData *
+skypeweb_fetch_url_request(SkypeWebAccount *sa,
+		const char *url, gboolean full, const char *user_agent, gboolean http11,
+		const char *request, gboolean include_headers, gssize max_len,
+		PurpleUtilFetchUrlCallback callback, void *user_data);


### PR DESCRIPTION
Fixes use-after-free bugs when the callback is called after the account is turned off.

This creates a wrapper function `skypeweb_fetch_url_request()` which takes a `SkypeWebAccount` instead of a `PurpleAccount`, and stores each return value in a linked list, `sa->url_datas`. The callbacks must take care of removing this entry.

The linked list idea is pretty much copy-pasted from built-in prpls, main difference is that others don't have a wrapper function.

This diff is rather repetitive, but it's as good as it gets.