### PR TITLE
Some small leak fixes

### DIFF
--- a/skypeweb/libskypeweb.c
+++ b/skypeweb/libskypeweb.c
@@ -230,7 +230,7 @@ skypeweb_join_chat(PurpleConnection *pc, GHashTable *data)
 	purple_conversation_present(PURPLE_CONVERSATION(chatconv));
 }
 
-static void
+void
 skypeweb_buddy_free(PurpleBuddy *buddy)
 {
 	SkypeWebBuddy *sbuddy = purple_buddy_get_protocol_data(buddy);
@@ -335,6 +335,7 @@ static void
 skypeweb_close(PurpleConnection *pc)
 {
 	SkypeWebAccount *sa;
+	GSList *buddies;
 	
 	g_return_if_fail(pc != NULL);
 	
@@ -371,6 +372,14 @@ skypeweb_close(PurpleConnection *pc)
 	while (sa->url_datas) {
 		purple_util_fetch_url_cancel(sa->url_datas->data);
 		sa->url_datas = g_slist_delete_link(sa->url_datas, sa->url_datas);
+	}
+
+	buddies = purple_find_buddies(sa->account, NULL);
+	while (buddies != NULL) {
+		PurpleBuddy *buddy = buddies->data;
+		skypeweb_buddy_free(buddy);
+		purple_buddy_set_protocol_data(buddy, NULL);
+		buddies = g_slist_delete_link(buddies, buddies);
 	}
 	
 	g_hash_table_destroy(sa->sent_messages_hash);

--- a/skypeweb/libskypeweb.h
+++ b/skypeweb/libskypeweb.h
@@ -292,6 +292,7 @@ struct _SkypeWebBuddy {
 	gchar *mood;
 };
 
+void skypeweb_buddy_free(PurpleBuddy *buddy);
 
 void skypeweb_do_all_the_things(SkypeWebAccount *sa);
 

--- a/skypeweb/skypeweb_contacts.c
+++ b/skypeweb/skypeweb_contacts.c
@@ -676,6 +676,9 @@ skypeweb_get_friend_list_cb(SkypeWebAccount *sa, JsonNode *node, gpointer user_d
 		
 		if (json_object_has_member(name, "surname"))
 			surname = json_object_get_string_member(name, "surname");
+
+		// try to free the sbuddy here. no-op if it's not set before, otherwise prevents a leak.
+		skypeweb_buddy_free(buddy);
 		
 		SkypeWebBuddy *sbuddy = g_new0(SkypeWebBuddy, 1);
 		sbuddy->skypename = g_strdup(id);

--- a/skypeweb/skypeweb_messages.c
+++ b/skypeweb/skypeweb_messages.c
@@ -987,11 +987,11 @@ skypeweb_subscribe(SkypeWebAccount *sa)
 static void
 skypeweb_got_registration_token(PurpleUtilFetchUrlData *url_data, gpointer user_data, const gchar *url_text, gsize len, const gchar *error_message)
 {
-	gchar *registration_token;
-	gchar *endpointId;
-	gchar *expires;
+	gchar *registration_token = NULL;
+	gchar *endpointId = NULL;
+	gchar *expires = NULL;
 	SkypeWebAccount *sa = user_data;
-	gchar *new_messages_host;
+	gchar *new_messages_host = NULL;
 
 	sa->url_datas = g_slist_remove(sa->url_datas, url_data);
 	
@@ -1023,6 +1023,7 @@ skypeweb_got_registration_token(PurpleUtilFetchUrlData *url_data, gpointer user_
 		skypeweb_get_registration_token(sa);
 		return;
 	}
+	g_free(new_messages_host);
 	
 	registration_token = skypeweb_string_get_chunk(url_text, len, "Set-RegistrationToken: ", ";");
 	endpointId = skypeweb_string_get_chunk(url_text, len, "endpointId=", "\r\n");
@@ -1138,6 +1139,7 @@ skypeweb_set_statusid(SkypeWebAccount *sa, const gchar *status)
 		gchar *url = g_strdup_printf("/v1/users/ME/endpoints/%s/presenceDocs/messagingService", purple_url_encode(sa->endpoint));
 		post = "{\"id\":\"messagingService\", \"type\":\"EndpointPresenceDoc\", \"selfLink\":\"uri\", \"privateInfo\":{\"epname\":\"skype\"}, \"publicInfo\":{\"capabilities\":\"\", \"type\":1, \"typ\":1, \"skypeNameVersion\":\"" SKYPEWEB_CLIENTINFO_VERSION "/" SKYPEWEB_CLIENTINFO_NAME "\", \"nodeInfo\":\"xx\", \"version\":\"" SKYPEWEB_CLIENTINFO_VERSION "\"}}";
 		skypeweb_post_or_get(sa, SKYPEWEB_METHOD_PUT | SKYPEWEB_METHOD_SSL, sa->messages_host, url, post, NULL, NULL, TRUE);
+		g_free(url);
 	}
 }
 


### PR DESCRIPTION
Looks valgrind clean to me now (after adding all the libpurple/gtk/cairo/rsvg/pixmap crap to suppressions...)

The `purple_find_buddies()` thing is almost-copied from a loop in `_purple_connection_destroy()` that is nulling the buddy protocol data before `prpl_info->buddy_free` is called. It sucks but it's also what it seems to expect the close prpl to do.

Quoting myself thinking aloud in the devel channel before reaching that conclusion:

>08:57 < dx> not sure what to do about this leak. account_disconnect happens before blist_uninit. the former sets buddy->proto_data to null, the latter calls prpl_info->buddy_free and finds a null, so it doesn't do anything. http://dump.dequis.org/MHbo1.txt
>09:01 < dx> hmmm http://dump.dequis.org/JDM8d.txt "that was freed in the prpl close method"

It probably would be safe to only call `skypeweb_buddy_free()` over each buddy and let `_purple_connection_destroy()` take care of deleting the rest, but it seems even safer to also null it.