### PR TITLE
Synced SPEC with upstream

### DIFF
--- a/skypeweb/README.md
+++ b/skypeweb/README.md
@@ -26,12 +26,10 @@ Building RPM package for Fedora/openSUSE/CentOS/RHEL
 ---------
 Requires devel headers/libs for libpurple and json-glib, gcc compiler and rpmbuild tool
 ```
-	sudo yum install rpm-build gcc json-glib-devel libpurple-devel zlib-devel make automake glib2-devel -y
+	sudo yum install rpm-build gcc json-glib-devel libpurple-devel zlib-devel make automake glib2-devel spectool -y
 	mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
-	wget https://raw.githubusercontent.com/EionRobb/skype4pidgin/master/skypeweb/purple-skypeweb.spec \
-		-O ~/rpmbuild/SPECS/purple-skypeweb.spec
-	wget https://github.com/EionRobb/skype4pidgin/archive/master.tar.gz \
-		-O ~/rpmbuild/SOURCES/skype4pidgin-1.0.tar.gz
+	wget https://github.com/EionRobb/skype4pidgin/raw/master/skypeweb/purple-skypeweb.spec -O ~/rpmbuild/SPECS/purple-skypeweb.spec
+	spectool --all --get-files ~/rpmbuild/SPECS/purple-skypeweb.spec --directory ~/rpmbuild/SOURCES/
 	rpmbuild -ba  ~/rpmbuild/SPECS/purple-skypeweb.spec
 ```
 The result can be found in ``~/rpmbuild/RPMS/`uname -m`/`` directory.

--- a/skypeweb/purple-skypeweb.spec
+++ b/skypeweb/purple-skypeweb.spec
@@ -1,56 +1,56 @@
-%global debug_package %{nil}
 %global plugin_name skypeweb
-%global purplelib_name purple-%{plugin_name}
 
-Name: skype4pidgin
+Name: purple-%{plugin_name}
 Version: 1.0
 Release: 2%{?dist}
-Summary: Skype plugin for Pidgin/Adium/libpurple
 License: GPLv3
-URL: https://github.com/EionRobb/%{name}
-Source0: https://github.com/EionRobb/%{name}/releases/download/v1.0/%{name}-%{version}.tar.gz
-Requires: pidgin-%{plugin_name}
-
-%description
-Skype for Pidgin meta package.
-
-%package -n %{purplelib_name}
+URL: https://github.com/EionRobb/skype4pidgin
+Source0: https://github.com/EionRobb/skype4pidgin/archive/v%{version}.tar.gz#/skype4pidgin-%{version}.tar.gz
 Summary: Adds support for Skype to Pidgin
 BuildRequires: pkgconfig(glib-2.0)
 BuildRequires: pkgconfig(purple)
 BuildRequires: pkgconfig(json-glib-1.0)
 BuildRequires: pkgconfig(zlib)
 BuildRequires: gcc
-BuildRequires: perl
-BuildRequires: gettext
 
-%package -n pidgin-%{plugin_name}
-Summary: Adds pixmaps, icons and smileys for Skype protocol.
-Requires: %{purplelib_name}
-Requires: pidgin
-
-%description -n %{purplelib_name}
+%description
 Adds support for Skype to Pidgin, Adium, Finch and other libpurple 
 based messengers.
+
+%package -n pidgin-%{plugin_name}
+Summary: Adds pixmaps, icons and smileys for Skype protocol
+BuildArch: noarch
+Requires: %{name} = %{version}-%{release}
+Requires: pidgin
 
 %description -n pidgin-%{plugin_name}
 Adds pixmaps, icons and smileys for Skype protocol inplemented by libskypeweb.
 
 %prep
-%autosetup
+%setup -qn skype4pidgin-%{version}
+cd %{plugin_name}
 
 # fix W: wrong-file-end-of-line-encoding
-perl -i -pe 's/\r\n/\n/gs' %{plugin_name}/README.md
+perl -i -pe 's/\r\n/\n/gs' README.md
+
+# generating empty configure script
+echo '#!/bin/bash' > configure
+chmod +x configure
 
 %build
 cd %{plugin_name}
+%configure
 %make_build
 
 %install
 cd %{plugin_name}
 %make_install
+chmod 755 %{buildroot}%{_libdir}/purple-2/lib%{plugin_name}.so
 
-%files -n %{purplelib_name}
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
+
+%files
 %{_libdir}/purple-2/lib%{plugin_name}.so
 %doc %{plugin_name}/README.md CHANGELOG.txt
 %license COPYING.txt
@@ -70,8 +70,6 @@ cd %{plugin_name}
 %dir %{_datadir}/pixmaps/pidgin/emotes
 %dir %{_datadir}/pixmaps/pidgin/emotes/skype
 %{_datadir}/pixmaps/pidgin/emotes/skype/theme
-
-%files
 
 %changelog
 * Thu Nov 26 2015 V1TSK <vitaly@easycoding.org> - 1.0-2


### PR DESCRIPTION
* Synced SPEC with upstream.
* Now using Fedora guidelines.
* Can be built with Fedora COPR and Koji: https://copr.fedoraproject.org/coprs/xvitaly/purple-skypeweb/build/143244/
* Debug info will be stripped by RPMBuild automatically.
* Added license and readme (required by Fedora upstream).