### PR TITLE
skypeweb_got_imagemessage: Pass a copy of the data to the imgstore

### DIFF
--- a/skypeweb/skypeweb_contacts.c
+++ b/skypeweb/skypeweb_contacts.c
@@ -118,7 +118,7 @@ skypeweb_got_imagemessage(PurpleUtilFetchUrlData *url_data, gpointer user_data, 
 	if (error_message && *error_message)
 		return;
 	
-	icon_id = purple_imgstore_add_with_id((gpointer)url_text, len, NULL);
+	icon_id = purple_imgstore_add_with_id(g_memdup(url_text, len), len, NULL);
 	
 	msg_tmp = g_strdup_printf("<img id='%d'>", icon_id);
 	purple_conversation_write(conv, conv->name, msg_tmp, PURPLE_MESSAGE_SYSTEM | PURPLE_MESSAGE_IMAGES, time(NULL));


### PR DESCRIPTION
`purple_imgstore_add_with_id()` borrows the reference to the image data, so passing a copy is needed to avoid double-free when the http request is cancelled and when the last reference to the imgstore entry is removed.

In the case of clients like bitlbee which don't keep a reference to the imgstore entry, this can mean an instant crash.

Fixes #374