### PR TITLE
Update skypeweb_contacts.c json_object_has_member bug fix

### DIFF
--- a/skypeweb/skypeweb_contacts.c
+++ b/skypeweb/skypeweb_contacts.c
@@ -1217,7 +1217,7 @@ skypeweb_get_friend_list_cb(SkypeWebAccount *sa, JsonNode *node, gpointer user_d
 			purple_blist_add_buddy(buddy, NULL, group, NULL);
 		}
 		
-		if (json_object_has_member(name, "surname"))
+		if (name && json_object_has_member(name, "surname"))
 			surname = json_object_get_string_member(name, "surname");
 
 		// try to free the sbuddy here. no-op if it's not set before, otherwise prevents a leak.


### PR DESCRIPTION
Fix this bug 

"(Pidgin:19936): Json-CRITICAL **: json_object_has_member: assertion `object != NULL' failed"

This happen when contacts are loaded and appear on advanced debug. 