### PR TITLE
Add alternative login methods

### DIFF
--- a/skypeweb/skypeweb_login.h
+++ b/skypeweb/skypeweb_login.h
@@ -28,5 +28,7 @@ void skypeweb_logout(SkypeWebAccount *sa);
 void skypeweb_begin_web_login(SkypeWebAccount *sa);
 void skypeweb_begin_oauth_login(SkypeWebAccount *sa);
 void skypeweb_refresh_token_login(SkypeWebAccount *sa);
+void skypeweb_begin_soapy_login(SkypeWebAccount *sa);
+void skypeweb_begin_skyper_login(SkypeWebAccount *sa);
 
 #endif /* SKYPEWEB_LOGIN_H */


### PR DESCRIPTION
These methods return better error messages, should be better at handling
reconnections (because only obvious auth errors are marked as such), and
will probably work with 2FA when combined with app passwords.

This adds two closely related methods that return skypetokens in a
fairly straightforward way.

- For skype usernames: api.skype.com/login/skypetoken
  Takes an old style skype md5 hash.
- For microsoft accounts: api.skype.com/rps/skypetoken
  Takes a ticket token (magic T) for "wl.skype.com"

The only complicated part is getting that token. One way could be to use
oauth with the code that is already implemented, but that's no fun.

Instead, this uses SOAP login (login.live.com/RST.srf) from the MSN era.
A little verbose but very reliable and simpler than scraping HTML.
And it gets decent error messages.

This is disabled by default, can be enabled with the "Use alternative
login method" setting.

Things left to be explored:

- It's technically possible to use SOAP login for skype usernames too,
but I got "Profile accrual is required" when I tried to request the
wl.skype.com scope. It works for other scopes.
- wl.skype.com and lw.skype.com are not the same thing, apparently.
- I'm not doing anything regarding the 24 hour expiration. I'm not sure
the term "refresh token" makes sense.
- This could be combined with oauth too, for fun.