### PR TITLE
Use the correct timestamp for image messages

### DIFF
--- a/skypeweb/purplecompat.h
+++ b/skypeweb/purplecompat.h
@@ -28,12 +28,6 @@
 //TODO remove this when dx adds this to the PurpleMessageFlags enum
 #define PURPLE_MESSAGE_REMOTE_SEND  0x10000
 
-static inline void purple_conversation_write_system_message_ts(PurpleConversation *conv, const gchar *msg, PurpleMessageFlags flags, time_t ts) {
-	PurpleMessage *pmsg = purple_message_new_system(msg, flags);
-	purple_message_set_time(pmsg, ts);
-	purple_conversation_write_message(conv, pmsg);
-}
-
 #else /*!PURPLE_VERSION_CHECK(3, 0, 0)*/
 
 #include "connection.h"
@@ -149,7 +143,6 @@ purple_message_destroy(PurpleMessage *message)
 #	define PURPLE_MESSAGE_REMOTE_SEND  0x10000
 #endif
 
-#define purple_conversation_write_system_message_ts(conv, msg, flags, ts)  purple_conversation_write((conv), NULL, (msg), (flags) | PURPLE_MESSAGE_SYSTEM, (ts));
 #define purple_conversation_write_system_message(conv, msg, flags)  purple_conversation_write((conv), NULL, (msg), (flags) | PURPLE_MESSAGE_SYSTEM, time(NULL));
 
 #define PurpleProtocolChatEntry  struct proto_chat_entry

--- a/skypeweb/purplecompat.h
+++ b/skypeweb/purplecompat.h
@@ -28,6 +28,12 @@
 //TODO remove this when dx adds this to the PurpleMessageFlags enum
 #define PURPLE_MESSAGE_REMOTE_SEND  0x10000
 
+static inline void purple_conversation_write_system_message_ts(PurpleConversation *conv, const gchar *msg, PurpleMessageFlags flags, time_t ts) {
+	PurpleMessage *pmsg = purple_message_new_system(msg, flags);
+	purple_message_set_time(pmsg, ts);
+	purple_conversation_write_message(conv, pmsg);
+}
+
 #else /*!PURPLE_VERSION_CHECK(3, 0, 0)*/
 
 #include "connection.h"
@@ -143,6 +149,7 @@ purple_message_destroy(PurpleMessage *message)
 #	define PURPLE_MESSAGE_REMOTE_SEND  0x10000
 #endif
 
+#define purple_conversation_write_system_message_ts(conv, msg, flags, ts)  purple_conversation_write((conv), NULL, (msg), (flags) | PURPLE_MESSAGE_SYSTEM, (ts));
 #define purple_conversation_write_system_message(conv, msg, flags)  purple_conversation_write((conv), NULL, (msg), (flags) | PURPLE_MESSAGE_SYSTEM, time(NULL));
 
 #define PurpleProtocolChatEntry  struct proto_chat_entry

--- a/skypeweb/skypeweb_contacts.c
+++ b/skypeweb/skypeweb_contacts.c
@@ -26,6 +26,14 @@
 #include "xfer.h"
 #include "image-store.h"
 
+static void purple_conversation_write_system_message_ts(
+		PurpleConversation *conv, const gchar *msg, PurpleMessageFlags flags,
+		time_t ts) {
+	PurpleMessage *pmsg = purple_message_new_system(msg, flags);
+	purple_message_set_time(pmsg, ts);
+	purple_conversation_write_message(conv, pmsg);
+}
+
 // Check that the conversation hasn't been closed
 static gboolean
 purple_conversation_is_valid(PurpleConversation *conv)

--- a/skypeweb/skypeweb_contacts.c
+++ b/skypeweb/skypeweb_contacts.c
@@ -117,16 +117,24 @@ skypeweb_get_icon(PurpleBuddy *buddy)
 	purple_timeout_add(100, skypeweb_get_icon_queuepop, (gpointer)buddy);
 }
 
+typedef struct SkypeImgMsgContext_ {
+	PurpleConversation *conv;
+	time_t composetimestamp;
+} SkypeImgMsgContext;
 
 static void
 skypeweb_got_imagemessage(PurpleHttpConnection *http_conn, PurpleHttpResponse *response, gpointer user_data)
 {
-	PurpleConversation *conv = user_data;
 	gint icon_id;
 	gchar *msg_tmp;
 	const gchar *url_text;
 	gsize len;
 	PurpleImage *image;
+	
+	SkypeImgMsgContext *ctx = user_data;
+	PurpleConversation *conv = ctx->conv;
+	time_t ts = ctx->composetimestamp;
+	g_free(ctx);
 	
 	// Conversation could have been closed before we retrieved the image
 	if (!purple_conversation_is_valid(conv)) {
@@ -144,12 +152,12 @@ skypeweb_got_imagemessage(PurpleHttpConnection *http_conn, PurpleHttpResponse *r
 	image = purple_image_new_from_data(g_memdup(url_text, len), len);
 	icon_id = purple_image_store_add(image);
 	msg_tmp = g_strdup_printf("<img id='%d'>", icon_id);
-	purple_conversation_write_system_message(conv, msg_tmp, PURPLE_MESSAGE_NO_LOG | PURPLE_MESSAGE_IMAGES);
+	purple_conversation_write_system_message_ts(conv, msg_tmp, PURPLE_MESSAGE_NO_LOG | PURPLE_MESSAGE_IMAGES, ts);
 	g_free(msg_tmp);
 }
 
 void
-skypeweb_download_uri_to_conv(SkypeWebAccount *sa, const gchar *uri, PurpleConversation *conv)
+skypeweb_download_uri_to_conv(SkypeWebAccount *sa, const gchar *uri, PurpleConversation *conv, time_t ts)
 {
 	gchar *url, *text;
 	PurpleHttpRequest *request;
@@ -158,16 +166,19 @@ skypeweb_download_uri_to_conv(SkypeWebAccount *sa, const gchar *uri, PurpleConve
 	purple_http_request_set_keepalive_pool(request, sa->keepalive_pool);
 	purple_http_request_header_set_printf(request, "Cookie", "skypetoken_asm=%s", sa->skype_token);
 	purple_http_request_header_set(request, "Accept", "image/*");
-	purple_http_request(sa->pc, request, skypeweb_got_imagemessage, conv);
+	SkypeImgMsgContext *ctx = g_new(SkypeImgMsgContext, 1);
+	ctx->composetimestamp = ts;
+	ctx->conv = conv;
+	purple_http_request(sa->pc, request, skypeweb_got_imagemessage, ctx);
 	purple_http_request_unref(request);
 
 	url = purple_strreplace(uri, "imgt1", "imgpsh_fullsize");
 	text = g_strdup_printf("<a href=\"%s\">Click here to view full version</a>", url);
-	purple_conversation_write_system_message(conv, text, PURPLE_MESSAGE_SYSTEM);
+	purple_conversation_write_system_message_ts(conv, text, PURPLE_MESSAGE_SYSTEM, ts);
 }
 
 void
-skypeweb_download_moji_to_conv(SkypeWebAccount *sa, const gchar *text, const gchar *url_thumbnail, PurpleConversation *conv)
+skypeweb_download_moji_to_conv(SkypeWebAccount *sa, const gchar *text, const gchar *url_thumbnail, PurpleConversation *conv, time_t ts)
 {
 	gchar *cdn_url_thumbnail;
 	PurpleHttpURL *httpurl;
@@ -181,10 +192,13 @@ skypeweb_download_moji_to_conv(SkypeWebAccount *sa, const gchar *text, const gch
 	purple_http_request_set_keepalive_pool(request, sa->keepalive_pool);
 	purple_http_request_header_set_printf(request, "Cookie", "vdms-skype-token=%s", sa->vdms_token);
 	purple_http_request_header_set(request, "Accept", "image/*");
-	purple_http_request(sa->pc, request, skypeweb_got_imagemessage, conv);
+	SkypeImgMsgContext *ctx = g_new(SkypeImgMsgContext, 1);
+	ctx->composetimestamp = ts;
+	ctx->conv = conv;
+	purple_http_request(sa->pc, request, skypeweb_got_imagemessage, ctx);
 	purple_http_request_unref(request);
 	
-	purple_conversation_write_system_message(conv, text, PURPLE_MESSAGE_SYSTEM);
+	purple_conversation_write_system_message_ts(conv, text, PURPLE_MESSAGE_SYSTEM, ts);
 
 	g_free(cdn_url_thumbnail);
 	purple_http_url_free(httpurl);

--- a/skypeweb/skypeweb_contacts.h
+++ b/skypeweb/skypeweb_contacts.h
@@ -22,9 +22,9 @@
 #include "libskypeweb.h"
 
 void skypeweb_get_icon(PurpleBuddy *buddy);
-void skypeweb_download_uri_to_conv(SkypeWebAccount *sa, const gchar *uri, PurpleConversation *conv);
+void skypeweb_download_uri_to_conv(SkypeWebAccount *sa, const gchar *uri, PurpleConversation *conv, time_t ts);
 void skypeweb_download_video_message(SkypeWebAccount *sa, const gchar *sid, PurpleConversation *conv);
-void skypeweb_download_moji_to_conv(SkypeWebAccount *sa, const gchar *text, const gchar *url_thumbnail, PurpleConversation *conv);
+void skypeweb_download_moji_to_conv(SkypeWebAccount *sa, const gchar *text, const gchar *url_thumbnail, PurpleConversation *conv, time_t ts);
 void skypeweb_present_uri_as_filetransfer(SkypeWebAccount *sa, const gchar *uri, const gchar *from);
 
 PurpleXfer *skypeweb_new_xfer(PurpleConnection *pc, const char *who);

--- a/skypeweb/skypeweb_messages.c
+++ b/skypeweb/skypeweb_messages.c
@@ -321,7 +321,7 @@ process_message_resource(SkypeWebAccount *sa, JsonObject *resource)
 			PurpleXmlNode *blob = purple_xmlnode_from_str(content, -1);
 			const gchar *uri = purple_xmlnode_get_attrib(blob, "url_thumbnail");
 			
-			skypeweb_download_uri_to_conv(sa, uri, conv);
+			skypeweb_download_uri_to_conv(sa, uri, conv, composetimestamp);
 			purple_xmlnode_free(blob);
 		} else {
 			purple_debug_warning("skypeweb", "Unhandled thread message resource messagetype '%s'\n", messagetype);
@@ -408,7 +408,7 @@ process_message_resource(SkypeWebAccount *sa, JsonObject *resource)
 				}
 				
 				conv = PURPLE_CONVERSATION(imconv);
-				skypeweb_download_uri_to_conv(sa, uri, conv);
+				skypeweb_download_uri_to_conv(sa, uri, conv, composetimestamp);
 			}
 			purple_xmlnode_free(blob);
 		} else if (g_str_equal(messagetype, "RichText/Media_GenericFile")) {
@@ -554,7 +554,7 @@ process_message_resource(SkypeWebAccount *sa, JsonObject *resource)
 				
 				conv = PURPLE_CONVERSATION(imconv);
 
-				skypeweb_download_moji_to_conv(sa, text, url_thumbnail, conv);
+				skypeweb_download_moji_to_conv(sa, text, url_thumbnail, conv, composetimestamp);
 
 				const gchar *message = _("The user sent a Moji");
 


### PR DESCRIPTION
The current implementation completely disregards the "composetime" member of
the received message if its type is RichText/UriObject or
RichText/Media_FlikMsg.

This results in the system messages with links to the images, as well as the
images themselves having the timestamp of the message's reception by the
client instead of the time when the message was actually sent.