### PR TITLE
g++ seems required

### DIFF
--- a/skypeweb/README.md
+++ b/skypeweb/README.md
@@ -81,7 +81,7 @@ Building DEB package for Debian/Ubuntu/Mint
 ---------
 Requires devel headers/libs for libpurple and json-glib, gcc compiler and cmake
 ```
-	sudo apt-get install libpurple-dev libjson-glib-dev cmake gcc
+	sudo apt-get install libpurple-dev libjson-glib-dev cmake gcc g++
 	git clone git://github.com/EionRobb/skype4pidgin.git
 	cd skype4pidgin/skypeweb
 	mkdir build


### PR DESCRIPTION
Hello,
I'm on Debian 9. 1 x86_64

My first failure
```sh
me@local:~/build/skype4pidgin/skypeweb/build$ cmake ..
-- The C compiler identification is GNU 6.3.0
-- The CXX compiler identification is unknown
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
CMake Error at CMakeLists.txt:8 (project):
  No CMAKE_CXX_COMPILER could be found.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.


-- Configuring incomplete, errors occurred!
See also "/home/me/build/skype4pidgin/skypeweb/build/CMakeFiles/CMakeOutput.log".
See also "/home/me/build/skype4pidgin/skypeweb/build/CMakeFiles/CMakeError.log".
```

Retry, same issue.

```sh
me@local:~/build/skype4pidgin/skypeweb/build$ cmake ..
-- The CXX compiler identification is unknown
CMake Error at CMakeLists.txt:8 (project):
  No CMAKE_CXX_COMPILER could be found.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.


-- Configuring incomplete, errors occurred!
See also "/home/me/build/skype4pidgin/skypeweb/build/CMakeFiles/CMakeOutput.log".
See also "/home/me/build/skype4pidgin/skypeweb/build/CMakeFiles/CMakeError.log".
```

Install the `g++` package.

```sh
me@local:~/build/skype4pidgin/skypeweb/build$ sudo apt-get install g++
[...]
```

Retry...

```sh
me@local:~/build/skype4pidgin/skypeweb/build$ cmake ..
-- The CXX compiler identification is GNU 6.3.0
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29") 
-- Checking for module 'glib-2.0'
--   Found glib-2.0, version 2.50.3
-- Checking for module 'json-glib-1.0'
--   Found json-glib-1.0, version 1.2.6
-- Checking for module 'purple'
--   Found purple, version 2.12.0
-- Configuring done
-- Generating done
-- Build files have been written to: /home/me/build/skype4pidgin/skypeweb/build
```

...Success!

PS: thanks for all your works done!