### PR TITLE
make PPFT error nonfatal for #474

### DIFF
--- a/skypeweb/skypeweb_login.c
+++ b/skypeweb/skypeweb_login.c
@@ -240,7 +240,7 @@ skypeweb_login_got_ppft(PurpleHttpConnection *http_conn, PurpleHttpResponse *res
 	// <input type="hidden" name="PPFT" id="i0327" value="..."/>
 	ppft = skypeweb_string_get_chunk(data, len, "name=\"PPFT\" id=\"i0327\" value=\"", "\"");
 	if (!ppft) {
-		purple_connection_error(sa->pc, PURPLE_CONNECTION_ERROR_AUTHENTICATION_FAILED, _("Failed getting PPFT value"));
+		purple_connection_error(sa->pc, PURPLE_CONNECTION_ERROR_NETWORK_ERROR, _("Failed getting PPFT value"));
 		return;
 	}
 	// CkTst=G + timestamp   e.g. G1422309314913


### PR DESCRIPTION
Often after I resume my laptop, Skype (HTTP) fails to get the PPFT value when Pidgin automatically reconnects. Currently the plugin marks a PPFT failure as a (fatal) authentication error, causing Pidgin to disable the account until the user clicks "Re-enable". (See issue #474.) But "Re-enable" has worked for me every single time I got the PPFT failure. These failures have behaved for me as temporary network errors, and the plugin ought to treat them as such.

Over the next few days, I will be dogfooding this patch on Pidgin 2.12.0 on Debian 9 "Stretch" on x86-64.