### PR TITLE
Implement support for contact suggestions

### DIFF
--- a/skypeweb/libskypeweb.c
+++ b/skypeweb/libskypeweb.c
@@ -730,6 +730,9 @@ PurpleConnection *pc
 
 	act = purple_protocol_action_new(_("Search for friends..."), skypeweb_search_users);
 	m = g_list_append(m, act);
+	
+	act = purple_protocol_action_new(_("People you might know..."), skypeweb_contact_suggestions);
+	m = g_list_append(m, act);
 
 	return m;
 }

--- a/skypeweb/libskypeweb.h
+++ b/skypeweb/libskypeweb.h
@@ -114,6 +114,7 @@
 #define SKYPEWEB_GRAPH_HOST "skypegraph.skype.com"
 #define SKYPEWEB_STATIC_HOST "static.asm.skype.com"
 #define SKYPEWEB_STATIC_CDN_HOST "static-asm.secure.skypeassets.com"
+#define SKYPEWEB_DEFAULT_CONTACT_SUGGESTIONS_HOST "peoplerecommendations.skype.com"
 
 #define SKYPEWEB_VDMS_TTL 300
 

--- a/skypeweb/skypeweb_connection.c
+++ b/skypeweb/skypeweb_connection.c
@@ -123,6 +123,12 @@ SkypeWebConnection *skypeweb_post_or_get(SkypeWebAccount *sa, SkypeWebMethod met
 		purple_http_request_header_set(request, "Referer", "https://web.skype.com/main");
 		purple_http_request_header_set(request, "Accept", "application/json; ver=1.0");
 		purple_http_request_header_set(request, "ClientInfo", "os=Windows; osVer=8.1; proc=Win32; lcid=en-us; deviceType=1; country=n/a; clientName=" SKYPEWEB_CLIENTINFO_NAME "; clientVer=" SKYPEWEB_CLIENTINFO_VERSION);
+	} else if (g_str_equal(host, SKYPEWEB_DEFAULT_CONTACT_SUGGESTIONS_HOST)) {
+		purple_http_request_header_set(request, "X-RecommenderServiceSettings", "{\"experiment\":\"default\",\"recommend\":\"true\"}");
+		purple_http_request_header_set(request, "X-ECS-ETag", SKYPEWEB_CLIENTINFO_NAME);
+		purple_http_request_header_set(request, "X-Skypetoken", sa->skype_token);
+		purple_http_request_header_set(request, "Accept", "application/json");
+		purple_http_request_header_set(request, "X-Skype-Client", SKYPEWEB_CLIENTINFO_VERSION);
 	} else {
 		purple_http_request_header_set(request, "Accept", "*/*");
 		purple_http_request_set_cookie_jar(request, sa->cookie_jar);

--- a/skypeweb/skypeweb_contacts.c
+++ b/skypeweb/skypeweb_contacts.c
@@ -939,7 +939,10 @@ create_search_results(JsonNode *node, gint *olength)
 	PurpleNotifySearchResults *results = purple_notify_searchresults_new();
 	if (results == NULL || length == 0)
 	{
-		*olength = 0;
+		if (olength)
+		{
+			*olength = 0;
+		}
 		return NULL;
 	}
 		
@@ -982,7 +985,10 @@ create_search_results(JsonNode *node, gint *olength)
 		purple_notify_searchresults_row_add(results, row);
 	}
 	
-	*olength = length;
+	if (olength)
+	{
+		*olength = length;
+	}
 	return results;
 }
 

--- a/skypeweb/skypeweb_contacts.c
+++ b/skypeweb/skypeweb_contacts.c
@@ -924,35 +924,23 @@ skypeweb_received_contacts(SkypeWebAccount *sa, PurpleXmlNode *contacts)
 	purple_notify_searchresults(sa->pc, _("Received contacts"), NULL, NULL, results, NULL, NULL);
 }
 
-void
-skypeweb_search_users_text_cb(SkypeWebAccount *sa, JsonNode *node, gpointer user_data)
+static PurpleNotifySearchResults*
+create_search_results(JsonNode *node, gint *olength)
 {
+	PurpleNotifySearchColumn *column;
+	gint index, length;
 	JsonObject *response = NULL;
 	JsonArray *resultsarray = NULL;
-	gint index, length;
-	gchar *search_term = user_data;
-
-	PurpleNotifySearchResults *results;
-	PurpleNotifySearchColumn *column;
 	
 	response = json_node_get_object(node);
 	resultsarray = json_object_get_array_member(response, "results");
 	length = json_array_get_length(resultsarray);
 	
-	if (length == 0)
+	PurpleNotifySearchResults *results = purple_notify_searchresults_new();
+	if (results == NULL || length == 0)
 	{
-		gchar *primary_text = g_strdup_printf("Your search for the user \"%s\" returned no results", search_term);
-		purple_notify_warning(sa->pc, "No users found", primary_text, "", purple_request_cpar_from_connection(sa->pc));
-		g_free(primary_text);
-		g_free(search_term);
-		return;
-	}
-	
-	results = purple_notify_searchresults_new();
-	if (results == NULL)
-	{
-		g_free(search_term);
-		return;
+		*olength = 0;
+		return NULL;
 	}
 		
 	/* columns: Friend ID, Name, Network */
@@ -994,7 +982,42 @@ skypeweb_search_users_text_cb(SkypeWebAccount *sa, JsonNode *node, gpointer user
 		purple_notify_searchresults_row_add(results, row);
 	}
 	
+	*olength = length;
+	return results;
+}
+
+static void
+skypeweb_search_users_text_cb(SkypeWebAccount *sa, JsonNode *node, gpointer user_data)
+{
+	gint length;
+	gchar *search_term = user_data;
+	PurpleNotifySearchResults *results = create_search_results(node, &length);
+	
+	if (results == NULL || length == 0)
+	{
+		gchar *primary_text = g_strdup_printf("Your search for the user \"%s\" returned no results", search_term);
+		purple_notify_warning(sa->pc, _("No users found"), primary_text, "", purple_request_cpar_from_connection(sa->pc));
+		g_free(primary_text);
+		g_free(search_term);
+		return;
+	}
+	
 	purple_notify_searchresults(sa->pc, NULL, search_term, NULL, results, NULL, NULL);
+}
+
+static void
+skypeweb_contact_suggestions_received_cb(SkypeWebAccount *sa, JsonNode *node, gpointer user_data)
+{
+	gint length;
+	PurpleNotifySearchResults *results = create_search_results(node, &length);
+	
+	if (results == NULL || length == 0)
+	{
+		purple_notify_warning(sa->pc, _("No results"), _("There are no contact suggestions available for you"), "", purple_request_cpar_from_connection(sa->pc));
+		return;
+	}
+	
+	purple_notify_searchresults(sa->pc, _("Contact suggestions"), NULL, NULL, results, NULL, NULL);
 }
 
 void
@@ -1028,8 +1051,18 @@ skypeweb_search_users(PurpleProtocolAction *action)
 
 }
 
-
-
+void
+skypeweb_contact_suggestions(PurpleProtocolAction *action)
+{
+	PurpleConnection *pc = purple_protocol_action_get_connection(action);
+	SkypeWebAccount *sa = purple_connection_get_protocol_data(pc);
+	
+	GString *url = g_string_new("/v1.1/recommend?requestId=1&locale=en-US&count=20");
+	
+	skypeweb_post_or_get(sa, SKYPEWEB_METHOD_GET | SKYPEWEB_METHOD_SSL, SKYPEWEB_DEFAULT_CONTACT_SUGGESTIONS_HOST, url->str, NULL, skypeweb_contact_suggestions_received_cb, 0, FALSE);
+	
+	g_string_free(url, TRUE);
+}
 
 static void
 skypeweb_got_friend_profiles(SkypeWebAccount *sa, JsonNode *node, gpointer user_data)

--- a/skypeweb/skypeweb_contacts.h
+++ b/skypeweb/skypeweb_contacts.h
@@ -52,4 +52,6 @@ gboolean skypeweb_check_authrequests(SkypeWebAccount *sa);
 
 void skypeweb_set_mood_message(SkypeWebAccount *sa, const gchar *mood);
 
+void skypeweb_contact_suggestions(PurpleProtocolAction *action);
+
 #endif /* SKYPEWEB_CONTACTS_H */


### PR DESCRIPTION
This PR adds support for the "People you may know" functionality found in the Skype desktop client, available while adding people to a chat.

The desktop client obtains the address and parameters of the "people suggestions" endpoint by making an appropriate call to `b.config.skype.com`, which supplies the address and the parameters which then are passed as `X-RecommenderServiceSettings`. Accessing the config resource also sends back the `ETag` header, which then must be passed into the endpoint as `X-ECS-ETag`. It is also necessary to provide a `X-Skype-Client` header.

However, during my testing, I found out that the server doesn't seem to care about the actual content of `X-ECS-ETag` or `X-Skype-Client` and accepts pretty much anything. Since accessing the config endpoint would be a much larger change, I decided to submit this version. The one which accesses the config resource while logging in is available in the [suggested-contacts](https://github.com/EionRobb/skype4pidgin/compare/master...xavery:suggested-contacts) branch - please let me know if you'd rather have that one merged in.