### PR TITLE
Fix "No handler found for resource" on alt login

### DIFF
--- a/skypeweb/libskypeweb.c
+++ b/skypeweb/libskypeweb.c
@@ -347,11 +347,7 @@ skypeweb_login(PurpleAccount *account)
 	sa->conns = purple_http_connection_set_new();
 
 	if (purple_account_get_bool(account, "alt-login", FALSE)) {
-		if (!SKYPEWEB_BUDDY_IS_MSN(purple_account_get_username(account))) {
-			skypeweb_begin_skyper_login(sa);
-		} else {
-			skypeweb_begin_soapy_login(sa);
-		}
+		skypeweb_begin_soapy_login(sa);
 	} else {
 		if (purple_account_get_string(account, "refresh-token", NULL) && purple_account_get_remember_password(account)) {
 			skypeweb_refresh_token_login(sa);

--- a/skypeweb/skypeweb_login.c
+++ b/skypeweb/skypeweb_login.c
@@ -374,24 +374,6 @@ fail:
 	g_free(error);
 }
 
-/* base64(md5(user + "\nskyper\n" + pass)) */
-static gchar *
-skypeweb_skyper_hash(const gchar *username, const gchar *password)
-{
-	guint8 hashed[16];
-	gsize len = sizeof(hashed);
-	GChecksum *gc;
-
-	gc = g_checksum_new(G_CHECKSUM_MD5);
-	g_checksum_update(gc, (guchar *)username, -1);
-	g_checksum_update(gc, (guchar *)"\nskyper\n", -1);
-	g_checksum_update(gc, (guchar *)password, -1);
-	g_checksum_get_digest(gc, hashed, &len);
-	g_checksum_free(gc);
-
-	return g_base64_encode(hashed, len);
-}
-
 static void
 skypeweb_login_get_api_skypetoken(SkypeWebAccount *sa, const gchar *url, const gchar *username, const gchar *password)
 {
@@ -426,7 +408,7 @@ skypeweb_login_get_api_skypetoken(SkypeWebAccount *sa, const gchar *url, const g
 static void
 skypeweb_login_soap_got_token(SkypeWebAccount *sa, gchar *token)
 {
-	const gchar *login_url = "https://api.skype.com/rps/skypetoken";
+	const gchar *login_url = "https://edge.skype.com/rps/v1/rps/skypetoken";
 
 	skypeweb_login_get_api_skypetoken(sa, login_url, NULL, token);
 }
@@ -546,20 +528,4 @@ skypeweb_begin_soapy_login(SkypeWebAccount *sa)
 	purple_connection_update_progress(sa->pc, _("Authenticating"), 2, 4);
 
 	g_free(postdata);
-}
-
-void
-skypeweb_begin_skyper_login(SkypeWebAccount *sa)
-{
-	gchar *hash;
-	const gchar *login_url = "https://api.skype.com/login/skypetoken";
-	const gchar *username = purple_account_get_username(sa->account);
-
-	hash = skypeweb_skyper_hash(username, purple_connection_get_password(sa->pc));
-
-	skypeweb_login_get_api_skypetoken(sa, login_url, username, hash);
-
-	purple_connection_update_progress(sa->pc, _("Authenticating"), 2, 4);
-
-	g_free(hash);
 }

--- a/skypeweb/skypeweb_login.h
+++ b/skypeweb/skypeweb_login.h
@@ -29,6 +29,5 @@ void skypeweb_begin_web_login(SkypeWebAccount *sa);
 void skypeweb_begin_oauth_login(SkypeWebAccount *sa);
 void skypeweb_refresh_token_login(SkypeWebAccount *sa);
 void skypeweb_begin_soapy_login(SkypeWebAccount *sa);
-void skypeweb_begin_skyper_login(SkypeWebAccount *sa);
 
 #endif /* SKYPEWEB_LOGIN_H */


### PR DESCRIPTION
That error is basically a 404 that you get when you set Accept to json
in the api.skype.com server.

The fix is to grab a new rps URL from skypeweb, it lives in the 'rps'
server (edge.skype.com) and has a slightly different path.

This also removes the 'skyper' md5-based login. It's still referenced in
the javascript of skypeweb, but probably unused because the endpoint is
the same we're hitting here and it's dead.

SOAP login still works with no issues, for both skype usernames and
microsoft accounts (it didn't work with skype usernames when i first
wrote this, but i remember at some point later throwing skype usernames
at the SOAP login and having it work)

For #639 