### PR TITLE
Fix build error (variable typo)

### DIFF
--- a/skypeweb/skypeweb_login.c
+++ b/skypeweb/skypeweb_login.c
@@ -165,7 +165,7 @@ skypeweb_login_got_t(PurpleHttpConnection *http_conn, PurpleHttpResponse *respon
 	data = purple_http_response_get_data(response, &len);
 	
 	// <input type="hidden" name="t" id="t" value="...">
-	error_test = skypeweb_string_get_chunk(data, len, ",sErrTxt:'", "',Am:'");
+	error_text = skypeweb_string_get_chunk(data, len, ",sErrTxt:'", "',Am:'");
 	error_code = skypeweb_string_get_chunk(data, len, ",sErrorCode:'", "',Ag:");
 	magic_t_value = skypeweb_string_get_chunk(data, len, "=\"t\" value=\"", "\"");
 
@@ -194,11 +194,11 @@ skypeweb_login_got_t(PurpleHttpConnection *http_conn, PurpleHttpResponse *respon
 			}
 		}
 
-		if (error_test) {
+		if (error_text) {
 			GString *new_error;
 			new_error = g_string_new("");
 			g_string_append_printf(new_error, "%s: ", error_code);
-			g_string_append_printf(new_error, "%s", error_test);
+			g_string_append_printf(new_error, "%s", error_text);
 
 			gchar *error_msg = g_string_free(new_error, FALSE);
 


### PR DESCRIPTION
There is variable typo causing build error.

/home/user/src/skype4pidgin/skypeweb/skypeweb_login.c: In function ‘skypeweb_login_got_t’:
/home/user/src/skype4pidgin/skypeweb/skypeweb_login.c:168:2: error: ‘error_test’ undeclared (first use in this function); did you mean ‘error_text’?
  error_test = skypeweb_string_get_chunk(data, len, ",sErrTxt:'", "',Am:'");
  ^~~~~~~~~~
  error_text
/home/user/src/skype4pidgin/skypeweb/skypeweb_login.c:168:2: note: each undeclared identifier is reported only once for each function it appears in
/home/user/src/skype4pidgin/skypeweb/skypeweb_login.c:160:9: warning: unused variable ‘error_text’ [-Wunused-variable]
  gchar *error_text;
         ^~~~~~~~~~
CMakeFiles/skypeweb.dir/build.make:110: recipe for target 'CMakeFiles/skypeweb.dir/skypeweb_login.c.o' failed
make[2]: *** [CMakeFiles/skypeweb.dir/skypeweb_login.c.o] Error 1
CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/skypeweb.dir/all' failed
make[1]: *** [CMakeFiles/skypeweb.dir/all] Error 2
Makefile:151: recipe for target 'all' failed
make: *** [all] Error 2
