### PR TITLE
Make the opid stage optional

### DIFF
--- a/skypeweb/skypeweb_login.c
+++ b/skypeweb/skypeweb_login.c
@@ -259,37 +259,34 @@ skypeweb_login_got_opid(PurpleHttpConnection *http_conn, PurpleHttpResponse *res
 	data = purple_http_response_get_data(response, &len);
 	
 	ppft = skypeweb_string_get_chunk(data, len, ",sFT:'", "',");
-	if (!ppft) {
-		purple_connection_error(sa->pc, PURPLE_CONNECTION_ERROR_AUTHENTICATION_FAILED, _("Failed getting PPFT value, please try logging in via browser first"));
-		return;
-	}
 	opid = skypeweb_string_get_chunk(data, len, "&opid=", "'");
-	if (!opid) {
-		purple_connection_error(sa->pc, PURPLE_CONNECTION_ERROR_AUTHENTICATION_FAILED, _("Failed getting opid value, try using 'Alternate Auth Method' settings"));
-		return;
-	}
-	postdata = g_string_new("");
-	g_string_append_printf(postdata, "opid=%s&", purple_url_encode(opid));
-	g_string_append(postdata, "site_name=lw.skype.com&");
-	g_string_append(postdata, "oauthPartner=999&");
-	g_string_append(postdata, "client_id=578134&");
-	g_string_append(postdata, "redirect_uri=https%3A%2F%2Fweb.skype.com&");
-	g_string_append_printf(postdata, "PPFT=%s&", purple_url_encode(ppft));
-	g_string_append(postdata, "type=28&");
+	if (!ppft || !opid) {
+		// Maybe this stage isn't needed this time: passing over the Magic T
+		skypeweb_login_got_t(http_conn, response, user_data);
+	} else {
+		postdata = g_string_new("");
+		g_string_append_printf(postdata, "opid=%s&", purple_url_encode(opid));
+		g_string_append(postdata, "site_name=lw.skype.com&");
+		g_string_append(postdata, "oauthPartner=999&");
+		g_string_append(postdata, "client_id=578134&");
+		g_string_append(postdata, "redirect_uri=https%3A%2F%2Fweb.skype.com&");
+		g_string_append_printf(postdata, "PPFT=%s&", purple_url_encode(ppft));
+		g_string_append(postdata, "type=28&");
 
-	tmplen = postdata->len;
-	if (postdata->len > INT_MAX) tmplen = INT_MAX;
-	
-	request = purple_http_request_new(live_login_url);
-	purple_http_request_set_method(request, "POST");
-	purple_http_request_set_cookie_jar(request, sa->cookie_jar);
-	purple_http_request_header_set(request, "Content-Type", "application/x-www-form-urlencoded; charset=UTF-8");
-	purple_http_request_header_set(request, "Accept", "*/*");
-	purple_http_request_set_contents(request, postdata->str, tmplen);
-	purple_http_request(sa->pc, request, skypeweb_login_got_t, sa);
-	purple_http_request_unref(request);
-	
-	g_string_free(postdata, TRUE);
+		tmplen = postdata->len;
+		if (postdata->len > INT_MAX) tmplen = INT_MAX;
+
+		request = purple_http_request_new(live_login_url);
+		purple_http_request_set_method(request, "POST");
+		purple_http_request_set_cookie_jar(request, sa->cookie_jar);
+		purple_http_request_header_set(request, "Content-Type", "application/x-www-form-urlencoded; charset=UTF-8");
+		purple_http_request_header_set(request, "Accept", "*/*");
+		purple_http_request_set_contents(request, postdata->str, tmplen);
+		purple_http_request(sa->pc, request, skypeweb_login_got_t, sa);
+		purple_http_request_unref(request);
+
+		g_string_free(postdata, TRUE);
+	}
 	
 	g_free(ppft);
 	g_free(opid);


### PR DESCRIPTION
M$ had enabled and disabled it recently, and who knows how many times they'll do it again. It should better be optional, so the users won't have to install different plugin versions every time.