### PR TITLE
Preliminary video attachment support

### DIFF
--- a/skypeweb/skypeweb_contacts.h
+++ b/skypeweb/skypeweb_contacts.h
@@ -20,9 +20,10 @@
 #define SKYPEWEB_CONTACTS_H
 
 #include "libskypeweb.h"
+#include "skypeweb_messages.h"
 
 void skypeweb_get_icon(PurpleBuddy *buddy);
-void skypeweb_download_uri_to_conv(SkypeWebAccount *sa, const gchar *uri, PurpleConversation *conv, time_t ts, const gchar* from);
+void skypeweb_download_uri_to_conv(SkypeWebAccount *sa, const gchar *uri, SkypeWebURIType uri_type, PurpleConversation *conv, time_t ts, const gchar* from);
 void skypeweb_download_video_message(SkypeWebAccount *sa, const gchar *sid, PurpleConversation *conv);
 void skypeweb_download_moji_to_conv(SkypeWebAccount *sa, const gchar *text, const gchar *url_thumbnail, PurpleConversation *conv, time_t ts, const gchar* from);
 void skypeweb_present_uri_as_filetransfer(SkypeWebAccount *sa, const gchar *uri, const gchar *from);

--- a/skypeweb/skypeweb_messages.h
+++ b/skypeweb/skypeweb_messages.h
@@ -21,6 +21,13 @@
 
 #include "libskypeweb.h"
 
+typedef enum
+{
+	SKYPEWEB_URI_TYPE_IMAGE,
+	SKYPEWEB_URI_TYPE_VIDEO,
+	SKYPEWEB_URI_TYPE_UNKNOWN
+} SkypeWebURIType;
+
 gint skypeweb_send_im(PurpleConnection *pc, 
 #if PURPLE_VERSION_CHECK(3, 0, 0)
 	PurpleMessage *msg


### PR DESCRIPTION
Message looks almost the same as image attachment hence logic is almost
the same. For now Pidgin displays thumbnail + link to full video while
Bitlbee shows link.