### PR TITLE
sa->pc safety check in request/timeout callbacks

### DIFF
--- a/skypeweb/skypeweb_connection.c
+++ b/skypeweb/skypeweb_connection.c
@@ -74,6 +74,7 @@ SkypeWebConnection *skypeweb_post_or_get(SkypeWebAccount *sa, SkypeWebMethod met
 	gchar *language_names;
 	gchar *real_url;
 	
+	g_return_val_if_fail(sa->pc != NULL, NULL);
 	g_return_val_if_fail(host != NULL, NULL);
 	g_return_val_if_fail(url != NULL, NULL);
 	

--- a/skypeweb/skypeweb_login.c
+++ b/skypeweb/skypeweb_login.c
@@ -27,6 +27,8 @@ skypeweb_login_did_auth(PurpleHttpConnection *http_conn, PurpleHttpResponse *res
 	SkypeWebAccount *sa = user_data;
 	const gchar *data;
 	gsize len;
+
+	g_return_if_fail(sa->pc);
 	
 	data = purple_http_response_get_data(response, &len);
 	
@@ -153,6 +155,8 @@ static void
 skypeweb_login_got_t(PurpleHttpConnection *http_conn, PurpleHttpResponse *response, gpointer user_data)
 {
 	SkypeWebAccount *sa = user_data;
+	g_return_if_fail(sa->pc);
+
 	const gchar *login_url = "https://" SKYPEWEB_LOGIN_HOST "/login/microsoft";
 	PurpleHttpRequest *request;
 	GString *postdata;
@@ -247,6 +251,8 @@ static void
 skypeweb_login_got_opid(PurpleHttpConnection *http_conn, PurpleHttpResponse *response, gpointer user_data)
 {
 	SkypeWebAccount *sa = user_data;
+	g_return_if_fail(sa->pc);
+
 	const gchar *live_login_url = "https://login.live.com" "/ppsecure/post.srf?wa=wsignin1.0&wp=MBI_SSL&wreply=https%3A%2F%2Flw.skype.com%2Flogin%2Foauth%2Fproxy%3Fsite_name%3Dlw.skype.com";
 	gchar *ppft;
 	gchar *opid;
@@ -298,6 +304,7 @@ static void
 skypeweb_login_got_ppft(PurpleHttpConnection *http_conn, PurpleHttpResponse *response, gpointer user_data)
 {
 	SkypeWebAccount *sa = user_data;
+	g_return_if_fail(sa->pc);
 	const gchar *live_login_url = "https://login.live.com" "/ppsecure/post.srf?wa=wsignin1.0&wp=MBI_SSL&wreply=https%3A%2F%2Flw.skype.com%2Flogin%2Foauth%2Fproxy%3Fsite_name%3Dlw.skype.com";
 	gchar *cktst_cookie;
 	gchar *ppft;
@@ -410,6 +417,8 @@ skypeweb_login_did_got_api_skypetoken(PurpleHttpConnection *http_conn, PurpleHtt
 	gchar *error = NULL;
 	PurpleConnectionError error_type = PURPLE_CONNECTION_ERROR_NETWORK_ERROR;
 
+	g_return_if_fail(sa->pc);
+
 	data = purple_http_response_get_data(response, &len);
 	
 	purple_debug_misc("skypeweb", "Full skypetoken response: %s\n", data);
@@ -503,6 +512,8 @@ skypeweb_login_did_soap(PurpleHttpConnection *http_conn, PurpleHttpResponse *res
 	PurpleXmlNode *envelope, *main_node, *node, *fault;
 	gchar *token;
 	const char *error = NULL;
+
+	g_return_if_fail(sa->pc);
 
 	data = purple_http_response_get_data(response, &len);
 	envelope = purple_xmlnode_from_str(data, len);

--- a/skypeweb/skypeweb_messages.c
+++ b/skypeweb/skypeweb_messages.c
@@ -1215,6 +1215,8 @@ skypeweb_got_registration_token(PurpleHttpConnection *http_conn, PurpleHttpRespo
 	gchar *new_messages_host = NULL;
 	const gchar *data;
 	gsize len;
+
+	g_return_if_fail(sa->pc);
 	
 	data = purple_http_response_get_data(response, &len);
 	
@@ -1282,6 +1284,8 @@ skypeweb_got_vdms_token(PurpleHttpConnection *http_conn, PurpleHttpResponse *res
 {
 	const gchar *token;
 	SkypeWebAccount *sa = user_data;
+	g_return_if_fail(sa->pc);
+
 	JsonParser *parser = json_parser_new();
 	const gchar *data;
 	gsize len;


### PR DESCRIPTION
It mitigates a common cause of segmentation faults due to a freed
SkypeAccount structure which may contain corrupted data already,
still the sa->pc may be NULL as it is freed right before the whole
structure. It does not guarantee the crash prevention though, and does
not solve the root problem, as these callbacks should be removed and
not invoked if an account is disconnected.

The crash backtraces are collected in #650, most of them happened in
`skypeweb_post_or_get`.
